### PR TITLE
feat: add chatMessageBuilder to the chatoptions to override default behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 5.0.0 - WIP
 - Get the color for the imagepicker from the Theme's primaryColor
+- Added chatMessageBuilder to the userstory configuration to customize the chat messages
 
 ## 4.0.0
 - Move to the new user story architecture

--- a/packages/flutter_chat/lib/src/config/chat_builders.dart
+++ b/packages/flutter_chat/lib/src/config/chat_builders.dart
@@ -17,6 +17,7 @@ class ChatBuilders {
     this.newChatButtonBuilder,
     this.noUsersPlaceholderBuilder,
     this.chatTitleBuilder,
+    this.chatMessageBuilder,
     this.usernameBuilder,
     this.loadingWidgetBuilder,
   });
@@ -62,6 +63,9 @@ class ChatBuilders {
   /// The chat title builder
   final Widget Function(String chatTitle)? chatTitleBuilder;
 
+  /// The chat message builder
+  final ChatMessageBuilder? chatMessageBuilder;
+
   /// The username builder
   final Widget Function(String userFullName)? usernameBuilder;
 
@@ -106,6 +110,17 @@ typedef BaseScreenBuilder = Widget Function(
 typedef ContainerBuilder = Widget Function(
   BuildContext context,
   Widget child,
+);
+
+/// The chat message builder
+/// This builder is used to override the default chat message widget
+/// If null is returned, the default chat message widget will be used so you can
+/// override for specific cases
+/// [previousMessage] is the previous message in the chat
+typedef ChatMessageBuilder = Widget? Function(
+  BuildContext context,
+  MessageModel message,
+  MessageModel? previousMessage,
 );
 
 /// The group avatar builder


### PR DESCRIPTION
With the chatMessageBuilder it is possible to run a null whenever you still want to use the default but only want to update the chat in very specific cases.
I also slightly refactored the chat_detail_screen.dart to remove duplicate code and make it more readable