### PR TITLE
feat: remove chatService and chatOptions from widget parameters to use ChatScope instead

### DIFF
--- a/packages/flutter_chat/lib/src/screens/chat_detail/chat_detail_screen.dart
+++ b/packages/flutter_chat/lib/src/screens/chat_detail/chat_detail_screen.dart
@@ -3,7 +3,6 @@ import "dart:typed_data";
 
 import "package:chat_repository_interface/chat_repository_interface.dart";
 import "package:flutter/material.dart";
-import "package:flutter_chat/src/config/chat_options.dart";
 import "package:flutter_chat/src/config/screen_types.dart";
 import "package:flutter_chat/src/screens/chat_detail/widgets/default_message_builder.dart";
 import "package:flutter_chat/src/screens/creation/widgets/image_picker.dart";
@@ -91,7 +90,7 @@ class _ChatDetailScreenState extends State<ChatDetailScreen> {
   @override
   Widget build(BuildContext context) {
     var chatScope = ChatScope.of(context);
-    var chatOptions = chatScope.options;
+    var options = chatScope.options;
     var appBar = _AppBar(
       chatTitle: chatTitle,
       onPressChatTitle: widget.onPressChatTitle,
@@ -113,14 +112,14 @@ class _ChatDetailScreenState extends State<ChatDetailScreen> {
       return () => chatScope.popHandler.remove(widget.onExit!);
     });
 
-    if (chatOptions.builders.baseScreenBuilder == null) {
+    if (options.builders.baseScreenBuilder == null) {
       return Scaffold(
         appBar: appBar,
         body: body,
       );
     }
 
-    return chatOptions.builders.baseScreenBuilder!.call(
+    return options.builders.baseScreenBuilder!.call(
       context,
       widget.mapScreenType,
       appBar,
@@ -305,7 +304,6 @@ class _BodyState extends State<_Body> {
                 widget.onUploadImage,
               ),
               onMessageSubmit: widget.onMessageSubmit,
-              options: options,
             ),
           ],
         ),
@@ -347,7 +345,6 @@ class _ChatBottom extends StatefulWidget {
   const _ChatBottom({
     required this.chat,
     required this.onMessageSubmit,
-    required this.options,
     this.onPressSelectImage,
   });
 
@@ -360,8 +357,6 @@ class _ChatBottom extends StatefulWidget {
   /// The chat model.
   final ChatModel chat;
 
-  final ChatOptions options;
-
   @override
   State<_ChatBottom> createState() => _ChatBottomState();
 }
@@ -373,6 +368,8 @@ class _ChatBottomState extends State<_ChatBottom> {
 
   @override
   Widget build(BuildContext context) {
+    var chatScope = ChatScope.of(context);
+    var options = chatScope.options;
     var theme = Theme.of(context);
 
     _textEditingController.addListener(() {
@@ -409,12 +406,12 @@ class _ChatBottomState extends State<_ChatBottom> {
           onPressed: widget.onPressSelectImage,
           icon: Icon(
             Icons.image_outlined,
-            color: widget.options.iconEnabledColor,
+            color: options.iconEnabledColor,
           ),
         ),
         IconButton(
-          disabledColor: widget.options.iconDisabledColor,
-          color: widget.options.iconEnabledColor,
+          disabledColor: options.iconDisabledColor,
+          color: options.iconEnabledColor,
           onPressed: onClickSendMessage,
           icon: const Icon(
             Icons.send_rounded,
@@ -446,7 +443,7 @@ class _ChatBottomState extends State<_ChatBottom> {
           vertical: 0,
           horizontal: 30,
         ),
-        hintText: widget.options.translations.messagePlaceholder,
+        hintText: options.translations.messagePlaceholder,
         hintStyle: theme.textTheme.bodyMedium,
         fillColor: Colors.white,
         filled: true,
@@ -467,11 +464,11 @@ class _ChatBottomState extends State<_ChatBottom> {
       ),
       child: SizedBox(
         height: 45,
-        child: widget.options.builders.messageInputBuilder?.call(
+        child: options.builders.messageInputBuilder?.call(
               context,
               _textEditingController,
               messageSendButtons,
-              widget.options.translations,
+              options.translations,
             ) ??
             defaultInputField,
       ),

--- a/packages/flutter_chat/lib/src/screens/chat_profile_screen.dart
+++ b/packages/flutter_chat/lib/src/screens/chat_profile_screen.dart
@@ -1,6 +1,5 @@
 import "package:chat_repository_interface/chat_repository_interface.dart";
 import "package:flutter/material.dart";
-import "package:flutter_chat/src/config/chat_options.dart";
 import "package:flutter_chat/src/config/screen_types.dart";
 import "package:flutter_chat/src/util/scope.dart";
 import "package:flutter_hooks/flutter_hooks.dart";
@@ -39,8 +38,6 @@ class ChatProfileScreen extends HookWidget {
   Widget build(BuildContext context) {
     var chatScope = ChatScope.of(context);
     var options = chatScope.options;
-    var service = chatScope.service;
-    var userId = chatScope.userId;
 
     useEffect(() {
       chatScope.popHandler.add(onExit);
@@ -50,13 +47,9 @@ class ChatProfileScreen extends HookWidget {
     var appBar = _AppBar(
       user: userModel,
       chat: chatModel,
-      options: options,
     );
 
     var body = _Body(
-      currentUser: userId,
-      options: options,
-      service: service,
       user: userModel,
       chat: chatModel,
       onTapUser: onTapUser,
@@ -83,15 +76,15 @@ class _AppBar extends StatelessWidget implements PreferredSizeWidget {
   const _AppBar({
     required this.user,
     required this.chat,
-    required this.options,
   });
 
   final UserModel? user;
   final ChatModel? chat;
-  final ChatOptions options;
 
   @override
   Widget build(BuildContext context) {
+    var chatScope = ChatScope.of(context);
+    var options = chatScope.options;
     var theme = Theme.of(context);
     return AppBar(
       iconTheme: theme.appBarTheme.iconTheme,
@@ -111,25 +104,23 @@ class _AppBar extends StatelessWidget implements PreferredSizeWidget {
 
 class _Body extends StatelessWidget {
   const _Body({
-    required this.options,
-    required this.service,
     required this.user,
     required this.chat,
     required this.onPressStartChat,
     required this.onTapUser,
-    required this.currentUser,
   });
 
-  final ChatOptions options;
-  final ChatService service;
   final UserModel? user;
   final ChatModel? chat;
   final Function(String)? onTapUser;
   final Function(String)? onPressStartChat;
-  final String currentUser;
 
   @override
   Widget build(BuildContext context) {
+    var chatScope = ChatScope.of(context);
+    var options = chatScope.options;
+    var service = chatScope.service;
+    var currentUser = chatScope.userId;
     var theme = Theme.of(context);
 
     var chatUserDisplay = Wrap(

--- a/packages/flutter_chat/lib/src/screens/creation/new_chat_screen.dart
+++ b/packages/flutter_chat/lib/src/screens/creation/new_chat_screen.dart
@@ -1,6 +1,5 @@
 import "package:chat_repository_interface/chat_repository_interface.dart";
 import "package:flutter/material.dart";
-import "package:flutter_chat/src/config/chat_options.dart";
 import "package:flutter_chat/src/config/screen_types.dart";
 import "package:flutter_chat/src/screens/creation/widgets/search_field.dart";
 import "package:flutter_chat/src/screens/creation/widgets/search_icon.dart";
@@ -41,8 +40,6 @@ class _NewChatScreenState extends State<NewChatScreen> {
   Widget build(BuildContext context) {
     var chatScope = ChatScope.of(context);
     var options = chatScope.options;
-    var service = chatScope.service;
-    var userId = chatScope.userId;
 
     useEffect(() {
       chatScope.popHandler.add(widget.onExit);
@@ -52,7 +49,6 @@ class _NewChatScreenState extends State<NewChatScreen> {
     if (options.builders.baseScreenBuilder == null) {
       return Scaffold(
         appBar: _AppBar(
-          chatOptions: options,
           isSearching: _isSearching,
           onSearch: (query) {
             setState(() {
@@ -73,12 +69,9 @@ class _NewChatScreenState extends State<NewChatScreen> {
           focusNode: _textFieldFocusNode,
         ),
         body: _Body(
-          chatOptions: options,
-          chatService: service,
           isSearching: _isSearching,
           onPressCreateGroupChat: widget.onPressCreateGroupChat,
           onPressCreateChat: widget.onPressCreateChat,
-          userId: userId,
           query: query,
         ),
       );
@@ -88,7 +81,6 @@ class _NewChatScreenState extends State<NewChatScreen> {
       context,
       widget.mapScreenType,
       _AppBar(
-        chatOptions: options,
         isSearching: _isSearching,
         onSearch: (query) {
           setState(() {
@@ -109,12 +101,9 @@ class _NewChatScreenState extends State<NewChatScreen> {
         focusNode: _textFieldFocusNode,
       ),
       _Body(
-        chatOptions: options,
-        chatService: service,
         isSearching: _isSearching,
         onPressCreateGroupChat: widget.onPressCreateGroupChat,
         onPressCreateChat: widget.onPressCreateChat,
-        userId: userId,
         query: query,
       ),
     );
@@ -123,14 +112,12 @@ class _NewChatScreenState extends State<NewChatScreen> {
 
 class _AppBar extends StatelessWidget implements PreferredSizeWidget {
   const _AppBar({
-    required this.chatOptions,
     required this.isSearching,
     required this.onSearch,
     required this.onPressedSearchIcon,
     required this.focusNode,
   });
 
-  final ChatOptions chatOptions;
   final bool isSearching;
   final Function(String) onSearch;
   final VoidCallback onPressedSearchIcon;
@@ -138,17 +125,18 @@ class _AppBar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Widget build(BuildContext context) {
+    var chatScope = ChatScope.of(context);
+    var options = chatScope.options;
     var theme = Theme.of(context);
 
     return AppBar(
       iconTheme: theme.appBarTheme.iconTheme ??
           const IconThemeData(color: Colors.white),
       title: SearchField(
-        chatOptions: chatOptions,
         isSearching: isSearching,
         onSearch: onSearch,
         focusNode: focusNode,
-        text: chatOptions.translations.newChatTitle,
+        text: options.translations.newChatTitle,
       ),
       actions: [
         SearchIcon(
@@ -165,20 +153,14 @@ class _AppBar extends StatelessWidget implements PreferredSizeWidget {
 
 class _Body extends StatelessWidget {
   const _Body({
-    required this.chatOptions,
-    required this.chatService,
     required this.isSearching,
     required this.onPressCreateGroupChat,
     required this.onPressCreateChat,
-    required this.userId,
     required this.query,
   });
 
-  final ChatOptions chatOptions;
-  final ChatService chatService;
   final bool isSearching;
 
-  final String userId;
   final String query;
 
   final VoidCallback onPressCreateGroupChat;
@@ -186,12 +168,16 @@ class _Body extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var translations = chatOptions.translations;
+    var chatScope = ChatScope.of(context);
+    var service = chatScope.service;
+    var options = chatScope.options;
+    var userId = chatScope.userId;
+    var translations = options.translations;
     var theme = Theme.of(context);
 
     return Column(
       children: [
-        if (chatOptions.groupChatEnabled && !isSearching) ...[
+        if (options.groupChatEnabled && !isSearching) ...[
           Padding(
             padding: const EdgeInsets.only(
               left: 32,
@@ -222,7 +208,7 @@ class _Body extends StatelessWidget {
         Expanded(
           child: StreamBuilder<List<UserModel>>(
             // ignore: discarded_futures
-            stream: chatService.getAllUsers(),
+            stream: service.getAllUsers(),
             builder: (context, snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
                 return const Center(child: CircularProgressIndicator());
@@ -233,11 +219,10 @@ class _Body extends StatelessWidget {
                   users: snapshot.data!,
                   currentUser: userId,
                   query: query,
-                  options: chatOptions,
                   onPressCreateChat: onPressCreateChat,
                 );
               } else {
-                return chatOptions.builders.noUsersPlaceholderBuilder
+                return options.builders.noUsersPlaceholderBuilder
                         ?.call(context, translations) ??
                     Padding(
                       padding: const EdgeInsets.symmetric(vertical: 20),

--- a/packages/flutter_chat/lib/src/screens/creation/new_group_chat_overview.dart
+++ b/packages/flutter_chat/lib/src/screens/creation/new_group_chat_overview.dart
@@ -2,7 +2,6 @@ import "dart:typed_data";
 
 import "package:chat_repository_interface/chat_repository_interface.dart";
 import "package:flutter/material.dart";
-import "package:flutter_chat/src/config/chat_options.dart";
 import "package:flutter_chat/src/config/screen_types.dart";
 import "package:flutter_chat/src/screens/creation/widgets/image_picker.dart";
 import "package:flutter_chat/src/util/scope.dart";
@@ -47,11 +46,8 @@ class NewGroupChatOverview extends HookWidget {
 
     if (options.builders.baseScreenBuilder == null) {
       return Scaffold(
-        appBar: _AppBar(
-          options: options,
-        ),
+        appBar: const _AppBar(),
         body: _Body(
-          options: options,
           users: users,
           onComplete: onComplete,
         ),
@@ -61,11 +57,8 @@ class NewGroupChatOverview extends HookWidget {
     return options.builders.baseScreenBuilder!.call(
       context,
       mapScreenType,
-      _AppBar(
-        options: options,
-      ),
+      const _AppBar(),
       _Body(
-        options: options,
         users: users,
         onComplete: onComplete,
       ),
@@ -74,14 +67,12 @@ class NewGroupChatOverview extends HookWidget {
 }
 
 class _AppBar extends StatelessWidget implements PreferredSizeWidget {
-  const _AppBar({
-    required this.options,
-  });
-
-  final ChatOptions options;
+  const _AppBar();
 
   @override
   Widget build(BuildContext context) {
+    var chatScope = ChatScope.of(context);
+    var options = chatScope.options;
     var theme = Theme.of(context);
     return AppBar(
       iconTheme: theme.appBarTheme.iconTheme ??
@@ -99,12 +90,10 @@ class _AppBar extends StatelessWidget implements PreferredSizeWidget {
 
 class _Body extends StatefulWidget {
   const _Body({
-    required this.options,
     required this.users,
     required this.onComplete,
   });
 
-  final ChatOptions options;
   final List<UserModel> users;
   final Function(
     List<UserModel> users,
@@ -147,8 +136,10 @@ class _BodyState extends State<_Body> {
 
   @override
   Widget build(BuildContext context) {
+    var chatScope = ChatScope.of(context);
+    var options = chatScope.options;
     var theme = Theme.of(context);
-    var translations = widget.options.translations;
+    var translations = options.translations;
     return Stack(
       children: [
         SingleChildScrollView(
@@ -168,7 +159,7 @@ class _BodyState extends State<_Body> {
                         InkWell(
                           onTap: () async => onPressSelectImage(
                             context,
-                            widget.options,
+                            options,
                             (image) {
                               setState(() {
                                 this.image = image;
@@ -322,7 +313,6 @@ class _BodyState extends State<_Body> {
                       ...users.map(
                         (e) => _SelectedUser(
                           user: e,
-                          options: widget.options,
                           onRemove: (user) {
                             setState(() {
                               users.remove(user);
@@ -387,47 +377,49 @@ class _BodyState extends State<_Body> {
 class _SelectedUser extends StatelessWidget {
   const _SelectedUser({
     required this.user,
-    required this.options,
     required this.onRemove,
   });
 
   final UserModel user;
-  final ChatOptions options;
   final Function(UserModel) onRemove;
 
   @override
-  Widget build(BuildContext context) => InkWell(
-        onTap: () {
-          onRemove(user);
-        },
-        child: Stack(
-          children: [
-            Padding(
-              padding: const EdgeInsets.all(8),
-              child: options.builders.userAvatarBuilder?.call(
-                    context,
-                    user,
-                    40,
-                  ) ??
-                  Avatar(
-                    boxfit: BoxFit.cover,
-                    user: User(
-                      firstName: user.firstName,
-                      lastName: user.lastName,
-                      imageUrl: user.imageUrl != "" ? user.imageUrl : null,
-                    ),
-                    size: 40,
+  Widget build(BuildContext context) {
+    var chatScope = ChatScope.of(context);
+    var options = chatScope.options;
+    return InkWell(
+      onTap: () {
+        onRemove(user);
+      },
+      child: Stack(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: options.builders.userAvatarBuilder?.call(
+                  context,
+                  user,
+                  40,
+                ) ??
+                Avatar(
+                  boxfit: BoxFit.cover,
+                  user: User(
+                    firstName: user.firstName,
+                    lastName: user.lastName,
+                    imageUrl: user.imageUrl != "" ? user.imageUrl : null,
                   ),
+                  size: 40,
+                ),
+          ),
+          Positioned.directional(
+            textDirection: Directionality.of(context),
+            end: 0,
+            child: const Icon(
+              Icons.cancel,
+              size: 20,
             ),
-            Positioned.directional(
-              textDirection: Directionality.of(context),
-              end: 0,
-              child: const Icon(
-                Icons.cancel,
-                size: 20,
-              ),
-            ),
-          ],
-        ),
-      );
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/packages/flutter_chat/lib/src/screens/creation/new_group_chat_screen.dart
+++ b/packages/flutter_chat/lib/src/screens/creation/new_group_chat_screen.dart
@@ -1,6 +1,5 @@
 import "package:chat_repository_interface/chat_repository_interface.dart";
 import "package:flutter/material.dart";
-import "package:flutter_chat/src/config/chat_options.dart";
 import "package:flutter_chat/src/config/screen_types.dart";
 import "package:flutter_chat/src/screens/creation/widgets/search_field.dart";
 import "package:flutter_chat/src/screens/creation/widgets/search_icon.dart";
@@ -38,18 +37,15 @@ class _NewGroupChatScreenState extends State<NewGroupChatScreen> {
   @override
   Widget build(BuildContext context) {
     var chatScope = ChatScope.of(context);
-    var chatOptions = chatScope.options;
-    var chatService = chatScope.service;
-    var userId = chatScope.userId;
+    var options = chatScope.options;
 
     useEffect(() {
       chatScope.popHandler.add(widget.onExit);
       return () => chatScope.popHandler.remove(widget.onExit);
     });
-    if (chatOptions.builders.baseScreenBuilder == null) {
+    if (options.builders.baseScreenBuilder == null) {
       return Scaffold(
         appBar: _AppBar(
-          chatOptions: chatOptions,
           isSearching: _isSearching,
           onSearch: (query) {
             setState(() {
@@ -73,20 +69,16 @@ class _NewGroupChatScreenState extends State<NewGroupChatScreen> {
           onSelectedUser: handleUserTap,
           selectedUsers: selectedUsers,
           onPressGroupChatOverview: widget.onContinue,
-          chatOptions: chatOptions,
-          chatService: chatService,
           isSearching: _isSearching,
-          userId: userId,
           query: query,
         ),
       );
     }
 
-    return chatOptions.builders.baseScreenBuilder!.call(
+    return options.builders.baseScreenBuilder!.call(
       context,
       widget.mapScreenType,
       _AppBar(
-        chatOptions: chatOptions,
         isSearching: _isSearching,
         onSearch: (query) {
           setState(() {
@@ -110,10 +102,7 @@ class _NewGroupChatScreenState extends State<NewGroupChatScreen> {
         onSelectedUser: handleUserTap,
         selectedUsers: selectedUsers,
         onPressGroupChatOverview: widget.onContinue,
-        chatOptions: chatOptions,
-        chatService: chatService,
         isSearching: _isSearching,
-        userId: userId,
         query: query,
       ),
     );
@@ -134,14 +123,12 @@ class _NewGroupChatScreenState extends State<NewGroupChatScreen> {
 
 class _AppBar extends StatelessWidget implements PreferredSizeWidget {
   const _AppBar({
-    required this.chatOptions,
     required this.isSearching,
     required this.onSearch,
     required this.onPressedSearchIcon,
     required this.focusNode,
   });
 
-  final ChatOptions chatOptions;
   final bool isSearching;
   final Function(String) onSearch;
   final VoidCallback onPressedSearchIcon;
@@ -149,17 +136,18 @@ class _AppBar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Widget build(BuildContext context) {
+    var chatScope = ChatScope.of(context);
+    var options = chatScope.options;
     var theme = Theme.of(context);
 
     return AppBar(
       iconTheme: theme.appBarTheme.iconTheme ??
           const IconThemeData(color: Colors.white),
       title: SearchField(
-        chatOptions: chatOptions,
         isSearching: isSearching,
         onSearch: onSearch,
         focusNode: focusNode,
-        text: chatOptions.translations.newGroupChatTitle,
+        text: options.translations.newGroupChatTitle,
       ),
       actions: [
         SearchIcon(
@@ -176,21 +164,15 @@ class _AppBar extends StatelessWidget implements PreferredSizeWidget {
 
 class _Body extends StatelessWidget {
   const _Body({
-    required this.chatOptions,
-    required this.chatService,
     required this.isSearching,
-    required this.userId,
     required this.query,
     required this.selectedUsers,
     required this.onSelectedUser,
     required this.onPressGroupChatOverview,
   });
 
-  final ChatOptions chatOptions;
-  final ChatService chatService;
   final bool isSearching;
 
-  final String userId;
   final String query;
 
   final List<UserModel> selectedUsers;
@@ -199,7 +181,11 @@ class _Body extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var translations = chatOptions.translations;
+    var chatScope = ChatScope.of(context);
+    var service = chatScope.service;
+    var options = chatScope.options;
+    var userId = chatScope.userId;
+    var translations = options.translations;
     var theme = Theme.of(context);
 
     return Column(
@@ -207,7 +193,7 @@ class _Body extends StatelessWidget {
         Expanded(
           child: StreamBuilder<List<UserModel>>(
             // ignore: discarded_futures
-            stream: chatService.getAllUsers(),
+            stream: service.getAllUsers(),
             builder: (context, snapshot) {
               if (snapshot.connectionState == ConnectionState.waiting) {
                 return const Center(child: CircularProgressIndicator());
@@ -220,7 +206,6 @@ class _Body extends StatelessWidget {
                       users: snapshot.data!,
                       currentUser: userId,
                       query: query,
-                      options: chatOptions,
                       onPressCreateChat: null,
                       creatingGroup: true,
                       selectedUsers: selectedUsers,
@@ -229,12 +214,11 @@ class _Body extends StatelessWidget {
                     _NextButton(
                       selectedUsers: selectedUsers,
                       onPressGroupChatOverview: onPressGroupChatOverview,
-                      chatOptions: chatOptions,
                     ),
                   ],
                 );
               } else {
-                return chatOptions.builders.noUsersPlaceholderBuilder
+                return options.builders.noUsersPlaceholderBuilder
                         ?.call(context, translations) ??
                     Padding(
                       padding: const EdgeInsets.symmetric(vertical: 20),
@@ -260,15 +244,15 @@ class _NextButton extends StatelessWidget {
   const _NextButton({
     required this.onPressGroupChatOverview,
     required this.selectedUsers,
-    required this.chatOptions,
   });
 
   final Function(List<UserModel>) onPressGroupChatOverview;
   final List<UserModel> selectedUsers;
-  final ChatOptions chatOptions;
 
   @override
   Widget build(BuildContext context) {
+    var chatScope = ChatScope.of(context);
+    var options = chatScope.options;
     var theme = Theme.of(context);
     return Align(
       alignment: Alignment.bottomCenter,
@@ -287,7 +271,7 @@ class _NextButton extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 Text(
-                  chatOptions.translations.next,
+                  options.translations.next,
                   style: theme.textTheme.displayLarge,
                 ),
               ],

--- a/packages/flutter_chat/lib/src/screens/creation/widgets/search_field.dart
+++ b/packages/flutter_chat/lib/src/screens/creation/widgets/search_field.dart
@@ -1,20 +1,16 @@
 import "package:flutter/material.dart";
-import "package:flutter_chat/src/config/chat_options.dart";
+import "package:flutter_chat/src/util/scope.dart";
 
 /// The search field widget
 class SearchField extends StatelessWidget {
   /// Constructs a [SearchField]
   const SearchField({
-    required this.chatOptions,
     required this.isSearching,
     required this.onSearch,
     required this.focusNode,
     required this.text,
     super.key,
   });
-
-  /// The chat options
-  final ChatOptions chatOptions;
 
   /// Whether the search field is currently in use
   final bool isSearching;
@@ -30,8 +26,10 @@ class SearchField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    var chatScope = ChatScope.of(context);
+    var options = chatScope.options;
     var theme = Theme.of(context);
-    var translations = chatOptions.translations;
+    var translations = options.translations;
 
     if (isSearching) {
       return TextField(

--- a/packages/flutter_chat/lib/src/screens/creation/widgets/user_list.dart
+++ b/packages/flutter_chat/lib/src/screens/creation/widgets/user_list.dart
@@ -1,6 +1,6 @@
 import "package:chat_repository_interface/chat_repository_interface.dart";
 import "package:flutter/material.dart";
-import "package:flutter_chat/src/config/chat_options.dart";
+import "package:flutter_chat/src/util/scope.dart";
 import "package:flutter_profile/flutter_profile.dart";
 
 /// The user list widget
@@ -10,7 +10,6 @@ class UserList extends StatefulWidget {
     required this.users,
     required this.currentUser,
     required this.query,
-    required this.options,
     required this.onPressCreateChat,
     this.creatingGroup = false,
     this.selectedUsers = const [],
@@ -26,9 +25,6 @@ class UserList extends StatefulWidget {
 
   /// The current user
   final String currentUser;
-
-  /// The chat options
-  final ChatOptions options;
 
   /// Whether the user is creating a group
   final bool creatingGroup;
@@ -60,8 +56,11 @@ class _UserListState extends State<UserList> {
 
   @override
   Widget build(BuildContext context) {
+    var chatScope = ChatScope.of(context);
+    var options = chatScope.options;
     var theme = Theme.of(context);
-    var translations = widget.options.translations;
+
+    var translations = options.translations;
     filteredUsers = widget.query.isNotEmpty
         ? users
             .where(
@@ -88,11 +87,11 @@ class _UserListState extends State<UserList> {
                 return handlePersonalChatTap(user);
               }
             },
-            child: widget.options.builders.chatRowContainerBuilder?.call(
+            child: options.builders.chatRowContainerBuilder?.call(
                   context,
                   Row(
                     children: [
-                      widget.options.builders.userAvatarBuilder
+                      options.builders.userAvatarBuilder
                               ?.call(context, user, 44) ??
                           Avatar(
                             boxfit: BoxFit.cover,
@@ -140,7 +139,7 @@ class _UserListState extends State<UserList> {
                     padding: const EdgeInsets.all(12),
                     child: Row(
                       children: [
-                        widget.options.builders.userAvatarBuilder
+                        options.builders.userAvatarBuilder
                                 ?.call(context, user, 44) ??
                             Avatar(
                               boxfit: BoxFit.cover,


### PR DESCRIPTION
This PR depends on https://github.com/Iconica-Development/flutter_chat/pull/122 so that has to be merged first.

For this PR I used the ChatScope everywhere. There are still a few places with userId being passed along but that would require more of a refactor which I will do at a later point (after the component is fully functional for beep)