### PR TITLE
feat: update ChatRepositoryInterface with methods to manage pagination of messages in a chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added FlutterChatDetailNavigatorUserstory that can be used to start the userstory from the chat detail screen without having the chat overview screen
 - Changed the ChatDetailScreen to use the chatId instead of the ChatModel, the screen will now fetch the chat from the ChatService
 - Changed baseScreenBuilder to include a chatTitle that can be used to show provide the title logic to apps that use the baseScreenBuilder
+- Added loadNewMessagesAfter, loadOldMessagesBefore and removed pagination from getMessages in the ChatRepositoryInterface to change pagination behavior to rely on the stream and two methods indicating that more messages should be added to the stream
 
 ## 4.0.0
 - Move to the new user story architecture

--- a/packages/chat_repository_interface/lib/src/interfaces/chat_repostory_interface.dart
+++ b/packages/chat_repository_interface/lib/src/interfaces/chat_repostory_interface.dart
@@ -43,16 +43,12 @@ abstract class ChatRepositoryInterface {
 
   /// Get the messages for the given [chatId].
   /// Returns a list of [MessageModel] stream.
-  /// [pageSize] is the number of messages to be fetched.
-  /// [page] is the page number.
   /// [userId] is the user id.
   /// [chatId] is the chat id.
   /// Returns a list of [MessageModel] stream.
   Stream<List<MessageModel>?> getMessages({
     required String chatId,
     required String userId,
-    required int pageSize,
-    required int page,
   });
 
   /// Get the message with the given [messageId].
@@ -61,6 +57,20 @@ abstract class ChatRepositoryInterface {
   Stream<MessageModel?> getMessage({
     required String chatId,
     required String messageId,
+  });
+
+  /// Signals that new messages should be loaded after the given message.
+  /// The stream should emit the new messages.
+  Future<void> loadNewMessagesAfter({
+    required String userId,
+    required MessageModel lastMessage,
+  });
+
+  /// Signals that old messages should be loaded before the given message.
+  /// The stream should emit the new messages.
+  Future<void> loadOldMessagesBefore({
+    required String userId,
+    required MessageModel firstMessage,
   });
 
   /// Send a message with the given parameters.

--- a/packages/chat_repository_interface/lib/src/services/chat_service.dart
+++ b/packages/chat_repository_interface/lib/src/services/chat_service.dart
@@ -135,14 +135,10 @@ class ChatService {
   /// Returns a list of [MessageModel] stream.
   Stream<List<MessageModel>?> getMessages({
     required String chatId,
-    required int pageSize,
-    required int page,
   }) =>
       chatRepository.getMessages(
         userId: userId,
         chatId: chatId,
-        pageSize: pageSize,
-        page: page,
       );
 
   /// Send a message with the given parameters.

--- a/packages/chat_repository_interface/lib/src/services/chat_service.dart
+++ b/packages/chat_repository_interface/lib/src/services/chat_service.dart
@@ -224,4 +224,9 @@ class ChatService {
 
     await chatRepository.updateChat(chat: newChat);
   }
+
+  /// Get all the users for the given [chatId].
+  /// Returns a list of [UserModel] stream.
+  Stream<List<UserModel>> getAllUsersForChat({required String chatId}) =>
+      userRepository.getAllUsersForChat(chatId: chatId);
 }

--- a/packages/firebase_chat_repository/lib/src/firebase_chat_repository.dart
+++ b/packages/firebase_chat_repository/lib/src/firebase_chat_repository.dart
@@ -94,15 +94,12 @@ class FirebaseChatRepository implements ChatRepositoryInterface {
   Stream<List<MessageModel>?> getMessages({
     required String chatId,
     required String userId,
-    required int pageSize,
-    required int page,
   }) =>
       _firestore
           .collection(_chatCollection)
           .doc(chatId)
           .collection(_messageCollection)
           .orderBy("timestamp")
-          .limit(pageSize)
           .snapshots()
           .map(
             (query) => query.docs
@@ -199,4 +196,16 @@ class FirebaseChatRepository implements ChatRepositoryInterface {
     var snapshot = await uploadTask.whenComplete(() => {});
     return snapshot.ref.getDownloadURL();
   }
+
+  @override
+  Future<void> loadNewMessagesAfter({
+    required String userId,
+    required MessageModel lastMessage,
+  }) async {}
+
+  @override
+  Future<void> loadOldMessagesBefore({
+    required String userId,
+    required MessageModel firstMessage,
+  }) async {}
 }

--- a/packages/flutter_chat/lib/src/config/chat_options.dart
+++ b/packages/flutter_chat/lib/src/config/chat_options.dart
@@ -21,7 +21,6 @@ class ChatOptions {
     this.iconDisabledColor,
     this.chatAlignment,
     this.onNoChats,
-    this.pageSize = 20,
     ChatRepositoryInterface? chatRepository,
     UserRepositoryInterface? userRepository,
   })  : chatRepository = chatRepository ?? LocalChatRepository(),
@@ -81,9 +80,6 @@ class ChatOptions {
 
   /// [onNoChats] is a function that is triggered when there are no chats.
   final Function? onNoChats;
-
-  /// [pageSize] is the number of chats to load at a time.
-  final int pageSize;
 }
 
 /// Typedef for the chatTitleResolver function that is used to get a title for

--- a/packages/flutter_chat/lib/src/screens/chat_detail/chat_detail_screen.dart
+++ b/packages/flutter_chat/lib/src/screens/chat_detail/chat_detail_screen.dart
@@ -50,18 +50,19 @@ class ChatDetailScreen extends HookWidget {
   Widget build(BuildContext context) {
     var chatScope = ChatScope.of(context);
     var options = chatScope.options;
+    var service = chatScope.service;
 
     var chatTitle = useState<String?>(null);
 
     var chatStream = useMemoized(
-      () => chatScope.service.getChat(chatId: chatId),
+      () => service.getChat(chatId: chatId),
       [chatId],
     );
     var chatSnapshot = useStream(chatStream);
     var chat = chatSnapshot.data;
 
     var allUsersStream = useMemoized(
-      () => options.userRepository.getAllUsersForChat(chatId: chatId),
+      () => service.getAllUsersForChat(chatId: chatId),
       [chatId],
     );
     var usersSnapshot = useStream(allUsersStream);

--- a/packages/flutter_chat/lib/src/screens/chat_detail/chat_detail_screen.dart
+++ b/packages/flutter_chat/lib/src/screens/chat_detail/chat_detail_screen.dart
@@ -226,7 +226,6 @@ class _Body extends HookWidget {
     var options = chatScope.options;
     var service = chatScope.service;
 
-    var pageSize = useState(chatScope.options.pageSize);
     var page = useState(0);
     var showIndicator = useState(false);
     var controller = useScrollController();
@@ -253,10 +252,8 @@ class _Body extends HookWidget {
     var messagesStream = useMemoized(
       () => service.getMessages(
         chatId: chat!.id,
-        pageSize: pageSize.value,
-        page: page.value,
       ),
-      [chat!.id, pageSize.value, page.value],
+      [chat!.id, page.value],
     );
     var messagesSnapshot = useStream(messagesStream);
     var messages = messagesSnapshot.data?.reversed.toList() ?? [];


### PR DESCRIPTION
After this I am going to update the pagination in the ChatDetailScreen to use the two extra methods to update the stream with more messages.
For now I removed pagination from the firebase implementaiotn because writing it in a proper way will take more work and can be done after the beep sprint is done.